### PR TITLE
Push validation against postgres to socket server

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function handler(event, context, callback) {
     // If we're under test, the test will pass in stub clients in context.stubs
     const stubs = context.stubs;
     const firehose = stubs.firehose || new aws.Firehose();
-    const publisherPromise = stubs.redis || getConnectedRedisClient(callback);
+    const publisherPromise = stubs.redisPublisher || getConnectedRedisClient(callback);
 
     // Kick off the publication steps.
     Promise.all([

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -94,11 +94,8 @@ const beehiveRecords = [
   }
 ];
 
-// We should pass all records to firehose
+// We should pass all records to firehose and redis
 // except those that are malformed.
-// `${o.network},${o.node},${o.datetime},${o.meta_id},${o.sensor},'${data}'\n`;
-// Key ordering in JSON.stringify not guaranteed, so we need to extract those 
-// and use an object deepEqual comparison to make sure we fot what we expected.
 
 const firehoseRows = [
     'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:51,1,bmi160,"{""orient_y"":1,""orient_z"":-1,""accel_z"":30,""orient_x"":3,""accel_y"":981,""accel_x"":-10}"',

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -1,5 +1,4 @@
 const beehiveRecords = [
-  // Will be split into two observations with 3 properties each
   {
     datetime: "2017-04-07 17:50:51",
     network: "array_of_things_chicago",
@@ -21,75 +20,6 @@ const beehiveRecords = [
     meta_id: 2,
     data: { temperature: 23.93 },
     sensor: "tmp112",
-    node_id: "0000001e0610b9e7"
-  },
-  {
-    datetime: "2017-04-07 17:50:51",
-    network: "array_of_things_chicago",
-    meta_id: 3,
-    data: { temperature: 38.43 },
-    sensor: "tmp421",
-    node_id: "0000001e0610b9e7"
-  },
-  // Will be one big observation
-  {
-    datetime: "2017-04-07 17:50:51",
-    network: "array_of_things_chicago",
-    meta_id: 4,
-    data: {
-      o3: 367816,
-      co: 4410,
-      reducing_gases: 77,
-      h2s: 24829,
-      no2: 2239,
-      so2: -362051,
-      oxidizing_gases: 34538
-    },
-    sensor: "chemsense",
-    node_id: "0000001e0610b9e7"
-  },
-  // Invalid observation: nonexistent beehive nickname
-  {
-    datetime: "2017-04-07 17:50:53",
-    network: "array_of_things_chicago",
-    meta_id: 5,
-    data: { foo: 38.43 },
-    sensor: "tmp421",
-    node_id: "0000001e0610b9e7"
-  },
-  // Invalid observation: nonexistent network
-  {
-    datetime: "2017-04-07 17:50:53",
-    network: "array_of_things_pittsburgh",
-    meta_id: 6,
-    data: { temperature: 38.43 },
-    sensor: "tmp421",
-    node_id: "0000001e0610b9e7"
-  },
-  // Invalid observation: nonexistent node
-  {
-    datetime: "2017-04-07 17:50:53",
-    network: "array_of_things_chicago",
-    meta_id: 7,
-    data: { temperature: 38.43 },
-    sensor: "tmp421",
-    node_id: "foo"
-  },
-  // Invalid observation: nonexistent sensor
-  {
-    datetime: "2017-04-07 17:50:53",
-    network: "array_of_things_chicago",
-    meta_id: 8,
-    data: { temperature: 38.43 },
-    sensor: "foo",
-    node_id: "0000001e0610b9e7"
-  },
-  // Malformed observation: missing field (datetime)
-  {
-    network: "array_of_things_chicago",
-    meta_id: 9,
-    data: { temperature: 38.43 },
-    sensor: "foo",
     node_id: "0000001e0610b9e7"
   }
 ];
@@ -99,17 +29,10 @@ const beehiveRecords = [
 
 const firehoseRows = [
     'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:51,1,bmi160,"{""orient_y"":1,""orient_z"":-1,""accel_z"":30,""orient_x"":3,""accel_y"":981,""accel_x"":-10}"',
-    'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:51,2,tmp112,"{""temperature"":23.93}"',
-    'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:51,3,tmp421,"{""temperature"":38.43}"',
-    'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:51,4,chemsense,"{""o3"":367816,""co"":4410,""reducing_gases"":77,""h2s"":24829,""no2"":2239,""so2"":-362051,""oxidizing_gases"":34538}"',
-    'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:53,5,tmp421,"{""foo"":38.43}"',
-    'array_of_things_pittsburgh,0000001e0610b9e7,2017-04-07T17:50:53,6,tmp421,"{""temperature"":38.43}"',
-    'array_of_things_chicago,foo,2017-04-07T17:50:53,7,tmp421,"{""temperature"":38.43}"',
-    'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:53,8,foo,"{""temperature"":38.43}"'
+    'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:51,2,tmp112,"{""temperature"":23.93}"'
 ]
 
 const redisRecords = [
-  // Will be split into two observations with 3 properties each
   {
     datetime: "2017-04-07T17:50:51",
     network: "array_of_things_chicago",
@@ -131,67 +54,6 @@ const redisRecords = [
     meta_id: 2,
     data: { temperature: 23.93 },
     sensor: "tmp112",
-    node: "0000001e0610b9e7"
-  },
-  {
-    datetime: "2017-04-07T17:50:51",
-    network: "array_of_things_chicago",
-    meta_id: 3,
-    data: { temperature: 38.43 },
-    sensor: "tmp421",
-    node: "0000001e0610b9e7"
-  },
-  // Will be one big observation
-  {
-    datetime: "2017-04-07T17:50:51",
-    network: "array_of_things_chicago",
-    meta_id: 4,
-    data: {
-      o3: 367816,
-      co: 4410,
-      reducing_gases: 77,
-      h2s: 24829,
-      no2: 2239,
-      so2: -362051,
-      oxidizing_gases: 34538
-    },
-    sensor: "chemsense",
-    node: "0000001e0610b9e7"
-  },
-  // Invalid observation: nonexistent beehive nickname
-  {
-    datetime: "2017-04-07T17:50:53",
-    network: "array_of_things_chicago",
-    meta_id: 5,
-    data: { foo: 38.43 },
-    sensor: "tmp421",
-    node: "0000001e0610b9e7"
-  },
-  // Invalid observation: nonexistent network
-  {
-    datetime: "2017-04-07T17:50:53",
-    network: "array_of_things_pittsburgh",
-    meta_id: 6,
-    data: { temperature: 38.43 },
-    sensor: "tmp421",
-    node: "0000001e0610b9e7"
-  },
-  // Invalid observation: nonexistent node
-  {
-    datetime: "2017-04-07T17:50:53",
-    network: "array_of_things_chicago",
-    meta_id: 7,
-    data: { temperature: 38.43 },
-    sensor: "tmp421",
-    node: "foo"
-  },
-  // Invalid observation: nonexistent sensor
-  {
-    datetime: "2017-04-07T17:50:53",
-    network: "array_of_things_chicago",
-    meta_id: 8,
-    data: { temperature: 38.43 },
-    sensor: "foo",
     node: "0000001e0610b9e7"
   }
 ]

--- a/tests/fixtures.js
+++ b/tests/fixtures.js
@@ -1,29 +1,3 @@
-const sensorTree = {
-  array_of_things_chicago: {
-    "0000001e0610b9e7": {
-      chemsense: {
-        co: "gas_concentration.co",
-        reducing_gases: "gas_concentration.reducing_gases",
-        h2s: "gas_concentration.h2s",
-        so2: "gas_concentration.so2",
-        oxidizing_gases: "gas_concentration.oxidizing_gases",
-        o3: "gas_concentration.o3",
-        no2: "gas_concentration.no2"
-      },
-      bmi160: {
-        accel_z: "acceleration.z",
-        accel_x: "acceleration.x",
-        accel_y: "acceleration.y",
-        orient_z: "orientation.z",
-        orient_x: "orientation.x",
-        orient_y: "orientation.y"
-      },
-      tmp421: { temperature: "temperature.internal_temperature" },
-      tmp112: { temperature: "temperature.temperature" }
-    }
-  }
-};
-
 const beehiveRecords = [
   // Will be split into two observations with 3 properties each
   {
@@ -126,7 +100,6 @@ const beehiveRecords = [
 // Key ordering in JSON.stringify not guaranteed, so we need to extract those 
 // and use an object deepEqual comparison to make sure we fot what we expected.
 
-// TODO: test quote around the JSON brackets
 const firehoseRows = [
     'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:51,1,bmi160,"{""orient_y"":1,""orient_z"":-1,""accel_z"":30,""orient_x"":3,""accel_y"":981,""accel_x"":-10}"',
     'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:51,2,tmp112,"{""temperature"":23.93}"',
@@ -138,91 +111,94 @@ const firehoseRows = [
     'array_of_things_chicago,0000001e0610b9e7,2017-04-07T17:50:53,8,foo,"{""temperature"":38.43}"'
 ]
 
-
-const redisObservations = [
+const redisRecords = [
+  // Will be split into two observations with 3 properties each
   {
-    type: "sensorObservations",
-    attributes: {
-      sensor: "bmi160",
-      node: "0000001e0610b9e7",
-      meta_id: 1,
-      network: "array_of_things_chicago",
-      datetime: "2017-04-07T17:50:51",
-      feature: "orientation",
-      properties: {
-        x: 3,
-        y: 1,
-        z: -1
-      }
-    }
+    datetime: "2017-04-07T17:50:51",
+    network: "array_of_things_chicago",
+    meta_id: 1,
+    data: {
+      orient_y: 1,
+      orient_z: -1,
+      accel_z: 30,
+      orient_x: 3,
+      accel_y: 981,
+      accel_x: -10
+    },
+    sensor: "bmi160",
+    node: "0000001e0610b9e7"
   },
   {
-    type: "sensorObservations",
-    attributes: {
-      sensor: "bmi160",
-      node: "0000001e0610b9e7",
-      meta_id: 1,
-      network: "array_of_things_chicago",
-      datetime: "2017-04-07T17:50:51",
-      feature: "acceleration",
-      properties: {
-        x: -10,
-        y: 981,
-        z: 30
-      }
-    }
+    datetime: "2017-04-07T17:50:51",
+    network: "array_of_things_chicago",
+    meta_id: 2,
+    data: { temperature: 23.93 },
+    sensor: "tmp112",
+    node: "0000001e0610b9e7"
   },
   {
-    type: "sensorObservations",
-    attributes: {
-      sensor: "tmp112",
-      node: "0000001e0610b9e7",
-      meta_id: 2,
-      network: "array_of_things_chicago",
-      datetime: "2017-04-07T17:50:51",
-      feature: "temperature",
-      properties: {
-        temperature: 23.93
-      }
-    }
+    datetime: "2017-04-07T17:50:51",
+    network: "array_of_things_chicago",
+    meta_id: 3,
+    data: { temperature: 38.43 },
+    sensor: "tmp421",
+    node: "0000001e0610b9e7"
   },
+  // Will be one big observation
   {
-    type: "sensorObservations",
-    attributes: {
-      sensor: "tmp421",
-      node: "0000001e0610b9e7",
-      meta_id: 3,
-      network: "array_of_things_chicago",
-      datetime: "2017-04-07T17:50:51",
-      feature: "temperature",
-      properties: {
-        internal_temperature: 38.43
-      }
-    }
+    datetime: "2017-04-07T17:50:51",
+    network: "array_of_things_chicago",
+    meta_id: 4,
+    data: {
+      o3: 367816,
+      co: 4410,
+      reducing_gases: 77,
+      h2s: 24829,
+      no2: 2239,
+      so2: -362051,
+      oxidizing_gases: 34538
+    },
+    sensor: "chemsense",
+    node: "0000001e0610b9e7"
   },
+  // Invalid observation: nonexistent beehive nickname
   {
-    type: "sensorObservations",
-    attributes: {
-      sensor: "chemsense",
-      node: "0000001e0610b9e7",
-      meta_id: 4,
-      network: "array_of_things_chicago",
-      datetime: "2017-04-07T17:50:51",
-      feature: "gas_concentration",
-      properties: {
-        o3: 367816,
-        co: 4410,
-        reducing_gases: 77,
-        h2s: 24829,
-        no2: 2239,
-        so2: -362051,
-        oxidizing_gases: 34538
-      }
-    }
+    datetime: "2017-04-07T17:50:53",
+    network: "array_of_things_chicago",
+    meta_id: 5,
+    data: { foo: 38.43 },
+    sensor: "tmp421",
+    node: "0000001e0610b9e7"
+  },
+  // Invalid observation: nonexistent network
+  {
+    datetime: "2017-04-07T17:50:53",
+    network: "array_of_things_pittsburgh",
+    meta_id: 6,
+    data: { temperature: 38.43 },
+    sensor: "tmp421",
+    node: "0000001e0610b9e7"
+  },
+  // Invalid observation: nonexistent node
+  {
+    datetime: "2017-04-07T17:50:53",
+    network: "array_of_things_chicago",
+    meta_id: 7,
+    data: { temperature: 38.43 },
+    sensor: "tmp421",
+    node: "foo"
+  },
+  // Invalid observation: nonexistent sensor
+  {
+    datetime: "2017-04-07T17:50:53",
+    network: "array_of_things_chicago",
+    meta_id: 8,
+    data: { temperature: 38.43 },
+    sensor: "foo",
+    node: "0000001e0610b9e7"
   }
-];
+]
 
 exports.beehiveRecords = beehiveRecords;
-exports.sensorTree = sensorTree;
 exports.firehoseRows = firehoseRows;
-exports.redisObservations = redisObservations;
+exports.redisRecords = redisRecords;

--- a/tests/testEmitter.js
+++ b/tests/testEmitter.js
@@ -3,20 +3,9 @@
     That will let you use this server to _just_ test interaction with the socket
     server in your laptop dev environment.
 */
-
-const Promise = require('bluebird');
 const {handler} = require('../index.js');
 
-const {sampleObservations, sampleTree} = require('./fixtures');
-
-// The lambda calls the postgres client's #query method
-// with a string calling the sensor_tree() stored procedure.
-// We just need to resolve with sensor tree JSON.
-const postgresStub = {
-    query(queryText) {
-        return Promise.resolve(sampleTree);
-    }
-}
+const {beehiveRecords} = require('./fixtures');
 
 // The lambda calls the firehose client's #putRecordBatch method,
 // and expects to chain a "#promise" call.
@@ -34,7 +23,7 @@ const firehoseStub = {
 // Try sending a fresh batch of observations every 15 seconds
 
 const recordsAsEvent = {
-    Records: sampleObservations.map(o => ({
+    Records: beehiveRecords.map(o => ({
         kinesis: {
             data: new Buffer(JSON.stringify(o), 'binary').toString('base64')
         }
@@ -44,7 +33,6 @@ const recordsAsEvent = {
 function sendABatch() {
     const context = {
         stubs: {
-            postgres: postgresStub,
             firehose: firehoseStub
         }
     }
@@ -52,4 +40,3 @@ function sendABatch() {
 }
 
 setInterval(sendABatch, 1000);
-

--- a/tests/travisTests/testIntegration.js
+++ b/tests/travisTests/testIntegration.js
@@ -8,15 +8,6 @@ const sinon = require('sinon');
 const fixtures = require('../fixtures.js');
 const handler = require('../../index').handler;
 
-const packageResult = sensor_tree => ({rows: [{sensor_tree}]});
-
-const pgClient = {
-    query() {
-        const result = {rows: [{sensor_tree: fixtures.sensorTree}]};
-        return Promise.resolve(result);
-    }
-}
-
 const redisClient = {
     publishAsync: sinon.stub().returns(Promise.resolve())
 }
@@ -49,7 +40,6 @@ describe('handler', function() {
     it('should publish data in the right formats to firehose and redis', function(done) {
         const context = {
             stubs: {
-                postgres: pgClient,
                 firehose: firehoseClient,
                 redisPublisher: redisClient
             }
@@ -66,29 +56,8 @@ describe('handler', function() {
 
                 // Test redis payload was as expected
                 const [channel, redisPayload] = redisClient.publishAsync.getCall(0).args;
-                
-                const observedObservations = _.pluck(JSON.parse(redisPayload), 'attributes');
-                const expectedObservations = _.pluck(fixtures.redisObservations, 'attributes');
-                expect(observedObservations.length).to.equal(expectedObservations.length);
-                
-                // Helper to avoid relying on ordering of the observations
-                function extractAndCompare(feature, meta) {
-                    const props = {feature, meta_id: meta};
-                    const observed = _.findWhere(observedObservations, props);
-                    const expected = _.findWhere(expectedObservations, props);
-                    expect(observed).to.be.ok;
-                    expect(observed).to.deep.equal(expected);
-                }
-                const pairs = [
-                    ['orientation', 1],
-                    ['acceleration', 1],
-                    ['temperature', 2],
-                    ['temperature', 3],
-                    ['gas_concentration', 4]
-                ]
-                for (let [feature, meta] of pairs) {
-                    extractAndCompare(feature, meta);
-                }
+                expect(JSON.parse(redisPayload)).to.deep.equal(fixtures.redisRecords);
+
                 done()
             }
             catch(e) {

--- a/tests/travisTests/testPublish.js
+++ b/tests/travisTests/testPublish.js
@@ -41,7 +41,7 @@ describe('handler', function() {
         const context = {
             stubs: {
                 firehose: firehoseClient,
-                redisPublisher: redisClient
+                redisPublisher: Promise.resolve(redisClient)
             }
         };
         function callback() {


### PR DESCRIPTION
This PR takes into account feedback from @HeyZoos on our last code review. He noted that we could trim execution time and complexity by _only_ invoking Postgres in the socket server. He also pointed out that I needed to be more rigorous about checking for Redis connection errors.

These edits make the lambda significantly simpler (largely because the complexity of validating and formatting observations is pushed out to the socket server).